### PR TITLE
UI : 스크랩 작성 페이지 완성, recoil persist로 모드 저장

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "styled-components": "^6.0.8",
         "typescript": "^4.9.5",
         "uuid": "^9.0.1",
@@ -14569,6 +14570,14 @@
         }
       }
     },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -27828,6 +27837,12 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
+    },
+    "recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "requires": {}
     },
     "recursive-readdir": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "styled-components": "^6.0.8",
     "typescript": "^4.9.5",
     "uuid": "^9.0.1",

--- a/src/asset/scrapWritePage/exit.svg
+++ b/src/asset/scrapWritePage/exit.svg
@@ -1,0 +1,3 @@
+<svg width="28" height="28" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.5 18H28.5M7.5 18L16.5 9M7.5 18L16.5 27" stroke="#5C5C5C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/atom/modal.tsx
+++ b/src/atom/modal.tsx
@@ -1,6 +1,10 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
 
 export const folderEditModal = atom({
   key: 'isfolderEditModalOpen',
-  default: false
+  default: false,
+  effects_UNSTABLE: [persistAtom]
 });

--- a/src/atom/mode.tsx
+++ b/src/atom/mode.tsx
@@ -1,6 +1,10 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
 
 export const modeState = atom({
   key: 'modeState',
-  default: 'light'
+  default: 'light',
+  effects_UNSTABLE: [persistAtom]
 });

--- a/src/components/Header/Header/Header.tsx
+++ b/src/components/Header/Header/Header.tsx
@@ -15,7 +15,7 @@ export type HeaderProps = {
   isWriteButton?: boolean;
 };
 
-const Header = ({ isWriteButton }: HeaderProps) => {
+const Header = ({ isWriteButton = true }: HeaderProps) => {
   const navigate = useNavigate();
   const mode = useRecoilValue(modeState);
 
@@ -45,7 +45,7 @@ const Header = ({ isWriteButton }: HeaderProps) => {
             height={35}
             color="positive"
             fontSize={18}
-            onClick={() => {}}
+            onClick={() => navigate('/scrap-write')}
           >
             <S.BasicButtonText>스크랩</S.BasicButtonText>
             <PencilIcon />

--- a/src/components/Header/Header/Header.tsx
+++ b/src/components/Header/Header/Header.tsx
@@ -11,9 +11,14 @@ import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { modeState } from '../../../atom/mode';
 
-const Header = () => {
+export type HeaderProps = {
+  isWriteButton?: boolean;
+};
+
+const Header = ({ isWriteButton }: HeaderProps) => {
   const navigate = useNavigate();
   const mode = useRecoilValue(modeState);
+
   return (
     <S.Wrapper>
       <S.LogoWrapper>
@@ -34,17 +39,20 @@ const Header = () => {
       </S.LogoWrapper>
       <S.BasicButtonWrapper>
         <ModeToggleButton />
-        <BasicButton
-          width={100}
-          height={35}
-          color="positive"
-          fontSize={18}
-          onClick={() => {}}
-        >
-          <S.BasicButtonText>스크랩</S.BasicButtonText>
-          <PencilIcon />
-        </BasicButton>
+        {isWriteButton && (
+          <BasicButton
+            width={100}
+            height={35}
+            color="positive"
+            fontSize={18}
+            onClick={() => {}}
+          >
+            <S.BasicButtonText>스크랩</S.BasicButtonText>
+            <PencilIcon />
+          </BasicButton>
+        )}
       </S.BasicButtonWrapper>
+
       <S.ProfileImgWrapper onClick={() => navigate('myPage')}>
         <CircleIcon size="small" imgUrl="" />
       </S.ProfileImgWrapper>

--- a/src/components/_common/LinkPreview/LinkPreview.tsx
+++ b/src/components/_common/LinkPreview/LinkPreview.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { S } from './style';
+
+const LinkPreview = () => {
+  return (
+    <S.Wrapper>
+      <S.Image src="https://ak-d.tripcdn.com/images/1mj1c12000bnc2cdm5451_C_800_600_R5.jpg_.webp?proc=autoorient" />
+      <S.ColumnWrapper>
+        <S.Title>풍요의 제주 ‘일멍쉬멍’ 워케이션 성지로</S.Title>
+        <S.Content>
+          바다와 맞닿아있는 해식애(해안 절벽) 봉우리, 제주 송악산에 오르니 이른
+          가을 바람에 옷깃이 흔들린다. 가파도와 마라도를 오가는 연락선의 뱃고동
+          소리가 들리고 북쪽 해안가 산방산과 용머리해안, 모슬봉이 미소 짓는다.
+          산신령이 제주도 세찬 바람에 단잠을 깨자 한라산 꼭대기를 발로 차
+          백록담을 만들고, 떨어진 꼭대기가 이곳까지 날아와 산방산이 되었다는
+          전설이 문득 떠오른다. 하지만 지질학적으로는 산방산이 한라산의 100만년
+          이상 선배다.
+        </S.Content>
+        <S.Source>출처 : 네이버 happycoding님의 블로그</S.Source>
+      </S.ColumnWrapper>
+    </S.Wrapper>
+  );
+};
+
+export default LinkPreview;

--- a/src/components/_common/LinkPreview/style.ts
+++ b/src/components/_common/LinkPreview/style.ts
@@ -1,0 +1,53 @@
+import { styled } from 'styled-components';
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 100%;
+  height: 140px;
+  border-radius: 6px;
+  box-shadow: ${({ theme }) => theme.boxShadow};
+  padding: 10px;
+  margin: 10px 0px;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const Image = styled.img`
+  height: 100%;
+`;
+
+const ColumnWrapper = styled.div`
+  flex: 1;
+  justify-content: space-between;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  margin-left: 12px;
+  padding: 6px;
+`;
+
+const Title = styled.div`
+  font-size: ${({ theme }) => theme.TEXT_SIZE['text-18']};
+`;
+
+const Content = styled.div`
+  height: 40px;
+  font-size: ${({ theme }) => theme.TEXT_SIZE['text-14']};
+
+  /* 두줄 말줄임표 */
+  overflow: hidden;
+  white-space: normal;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: keep-all;
+`;
+
+const Source = styled.div`
+  color: ${({ theme }) => theme.COLOR.darkGrey};
+  font-size: ${({ theme }) => theme.TEXT_SIZE['text-12']};
+`;
+
+export const S = { Wrapper, Image, ColumnWrapper, Title, Content, Source };

--- a/src/components/_common/Tag/style.ts
+++ b/src/components/_common/Tag/style.ts
@@ -9,7 +9,7 @@ const Wrapper = styled.div`
   font-weight: bold;
   color: white;
   padding: 6px 12px;
-  margin: 0px 6px;
+  margin: 6px 6px;
   border-radius: 30px;
   background: ${({ theme }) => theme.COLOR.mint};
 

--- a/src/components/_common/Tag/style.ts
+++ b/src/components/_common/Tag/style.ts
@@ -7,7 +7,7 @@ const Wrapper = styled.div`
   height: 32px;
   font-size: 14px;
   font-weight: bold;
-  color: ${({ theme }) => theme.background};
+  color: white;
   padding: 6px 12px;
   margin: 0px 6px;
   border-radius: 30px;

--- a/src/components/_common/TagCreator/TagCreator.tsx
+++ b/src/components/_common/TagCreator/TagCreator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { TagType } from 'types/TagType';
 import Tag from '../Tag/Tag';
 import { S } from './style';
@@ -25,6 +25,16 @@ const TagCreator = () => {
     setTags((currTags) => currTags.filter((tag) => tag.id !== id));
   };
 
+  const inputWidthRef = useRef<HTMLSpanElement>(null);
+
+  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value);
+    // 인풋의 가로길이 자동 조절
+    if (inputWidthRef !== null && inputWidthRef.current !== null) {
+      inputWidthRef.current.innerHTML = e.target.value;
+    }
+  };
+
   return (
     <S.Wrapper>
       {/* 태그 리스트 */}
@@ -32,12 +42,17 @@ const TagCreator = () => {
         <Tag key={index} tag={tag} onDelete={onDelete} />
       ))}
       {/* 태그 입력창 */}
-      <S.Input
-        placeholder="태그를 입력하세요"
-        value={input}
-        onChange={(e) => setInput(e.target.value)}
-        onKeyDown={onEnter}
-      />
+      <S.InputWrapper>
+        <S.InputWidth ref={inputWidthRef} aria-hidden="true"></S.InputWidth>
+        <S.Input
+          className="input"
+          placeholder="태그를 입력하세요"
+          value={input}
+          onChange={onChangeInput}
+          onKeyDown={onEnter}
+          $empty={!input}
+        />
+      </S.InputWrapper>
     </S.Wrapper>
   );
 };

--- a/src/components/_common/TagCreator/style.ts
+++ b/src/components/_common/TagCreator/style.ts
@@ -10,6 +10,8 @@ const Wrapper = styled.div`
 
 const Input = styled.input`
   padding: 0px 6px;
+  color: inherit;
+  background: inherit;
 `;
 
 export const S = { Wrapper, Input };

--- a/src/components/_common/TagCreator/style.ts
+++ b/src/components/_common/TagCreator/style.ts
@@ -2,16 +2,33 @@ import styled from 'styled-components';
 import { flexCenter } from 'style/common';
 
 const Wrapper = styled.div`
+  width: 100%;
   ${flexCenter};
   justify-content: start;
   transform: translateX(-6px);
-  height: 32px;
+  flex-wrap: wrap;
 `;
 
-const Input = styled.input`
-  padding: 0px 6px;
+const InputWrapper = styled.span`
+  padding: 6px 0px;
+  margin: 6px 6px;
+  height: 32px;
+  position: relative;
+`;
+
+const InputWidth = styled.span`
+  visibility: hidden;
+  padding: 0 1rem;
+`;
+
+const Input = styled.input<{ $empty: boolean }>`
   color: inherit;
   background: inherit;
+  font-size: ${({ theme }) => theme.TEXT_SIZE['text-16']};
+  position: absolute;
+  width: 100%;
+  min-width: ${({ $empty }) => $empty && '140px'};
+  left: 0;
 `;
 
-export const S = { Wrapper, Input };
+export const S = { Wrapper, InputWrapper, InputWidth, Input };

--- a/src/layout/headerLayout/HeaderLayout.tsx
+++ b/src/layout/headerLayout/HeaderLayout.tsx
@@ -1,12 +1,12 @@
-import Header from 'components/Header/Header/Header';
+import Header, { HeaderProps } from 'components/Header/Header/Header';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { S } from './style';
 
-const HeaderLayout = () => {
+const HeaderLayout = ({ isWriteButton = true }: HeaderProps) => {
   return (
     <S.Wrapper>
-      <Header />
+      <Header isWriteButton={isWriteButton} />
       <S.ContentWrapper>
         <Outlet />
       </S.ContentWrapper>

--- a/src/pages/ScrapWritePage/ScrapWritePage.tsx
+++ b/src/pages/ScrapWritePage/ScrapWritePage.tsx
@@ -7,12 +7,14 @@ import { ReactComponent as ExitIcon } from 'asset/scrapWritePage/exit.svg';
 import { Category, CategoryValuesType } from 'constants/Category';
 import TagCreator from 'components/_common/TagCreator/TagCreator';
 import BasicButton from 'components/_common/BasicButton/BasicButton';
+import LinkPreview from 'components/_common/LinkPreview/LinkPreview';
 
 const ScrapWritePage = () => {
   const [category, setCategory] = useState<CategoryValuesType>();
   const [categoryOpen, setCategoryOpen] = useState(false);
   const [title, setTitle] = useState('');
   const [link, setLink] = useState('');
+  const [showLinkPreview, setShowLinkPreview] = useState(false);
   const [imgFile, setImgFile] = useState('');
   const [content, setContent] = useState('');
 
@@ -20,8 +22,16 @@ const ScrapWritePage = () => {
   const titleRef = useRef<HTMLTextAreaElement>(null);
   const contentRef = useRef<HTMLTextAreaElement>(null);
 
-  // 이미지 업로드 input의 onChange 이벤트 핸들러
-  const previewImage = () => {
+  // 링크 업로드 이벤트 핸들러
+  const onLinkUpload = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && link) {
+      console.log(link, '링크 미리보기 생성');
+      setShowLinkPreview(true);
+    }
+  };
+
+  // 이미지 업로드 이벤트 핸들러
+  const onImageUpload = () => {
     if (imgRef.current !== null && imgRef.current.files !== null) {
       const file = imgRef.current.files[0];
       const reader = new FileReader();
@@ -81,11 +91,18 @@ const ScrapWritePage = () => {
         {/* 링크 */}
         <S.LinkWrapper>
           <LinkIcon />
-          <S.Link
-            value={link}
-            onChange={(e) => setLink(e.target.value)}
-            placeholder="링크를 입력하세요."
-          />
+          <S.LinkColumnWrapper>
+            <S.Link
+              value={link}
+              onChange={(e) => {
+                setLink(e.target.value);
+                setShowLinkPreview(false);
+              }}
+              onKeyDown={onLinkUpload}
+              placeholder="링크를 입력하세요."
+            />
+            {showLinkPreview && <LinkPreview />}
+          </S.LinkColumnWrapper>
         </S.LinkWrapper>
         {/* 이미지 */}
         <S.ImageWrapper>
@@ -96,7 +113,7 @@ const ScrapWritePage = () => {
             id="image"
             type="file"
             accept="image/*"
-            onChange={previewImage}
+            onChange={onImageUpload}
             ref={imgRef}
             style={{ display: 'none' }}
           />

--- a/src/pages/ScrapWritePage/ScrapWritePage.tsx
+++ b/src/pages/ScrapWritePage/ScrapWritePage.tsx
@@ -3,8 +3,10 @@ import { S } from './style';
 import { ReactComponent as ArrowIcon } from 'asset/arrow/downArrow.svg';
 import { ReactComponent as LinkIcon } from 'asset/scrapWritePage/link.svg';
 import { ReactComponent as ImageIcon } from 'asset/scrapWritePage/image.svg';
+import { ReactComponent as ExitIcon } from 'asset/scrapWritePage/exit.svg';
 import { Category, CategoryValuesType } from 'constants/Category';
 import TagCreator from 'components/_common/TagCreator/TagCreator';
+import BasicButton from 'components/_common/BasicButton/BasicButton';
 
 const ScrapWritePage = () => {
   const [category, setCategory] = useState<CategoryValuesType>();
@@ -12,10 +14,14 @@ const ScrapWritePage = () => {
   const [title, setTitle] = useState('');
   const [link, setLink] = useState('');
   const [imgFile, setImgFile] = useState('');
-  const imgRef = useRef<HTMLInputElement>(null);
+  const [content, setContent] = useState('');
 
-  // 이미지 업로드 input의 onChange
-  const saveImgFile = () => {
+  const imgRef = useRef<HTMLInputElement>(null);
+  const titleRef = useRef<HTMLTextAreaElement>(null);
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
+  // 이미지 업로드 input의 onChange 이벤트 핸들러
+  const previewImage = () => {
     if (imgRef.current !== null && imgRef.current.files !== null) {
       const file = imgRef.current.files[0];
       const reader = new FileReader();
@@ -23,6 +29,24 @@ const ScrapWritePage = () => {
       reader.onloadend = () => {
         setImgFile(reader.result as string);
       };
+    }
+  };
+
+  const onChangeTitle = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTitle(e.target.value);
+    // 제목의 높이 자동조절
+    if (titleRef !== null && titleRef.current !== null) {
+      titleRef.current.style.height = 'auto';
+      titleRef.current.style.height = titleRef.current.scrollHeight + 'px';
+    }
+  };
+
+  const onChangeContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(e.target.value);
+    // 내용의 높이 자동조절
+    if (contentRef !== null && contentRef.current !== null) {
+      contentRef.current.style.height = 'auto';
+      contentRef.current.style.height = contentRef.current.scrollHeight + 'px';
     }
   };
 
@@ -45,9 +69,12 @@ const ScrapWritePage = () => {
             </S.CategoryList>
           )}
         </S.CategoryDropdown>
+        {/* 제목 */}
         <S.Title
+          rows={1}
+          ref={titleRef}
           value={title}
-          onChange={(e) => setTitle(e.target.value)}
+          onChange={onChangeTitle}
           placeholder="제목을 입력하세요"
         />
         <TagCreator />
@@ -69,17 +96,33 @@ const ScrapWritePage = () => {
             id="image"
             type="file"
             accept="image/*"
-            onChange={saveImgFile}
+            onChange={previewImage}
             ref={imgRef}
             style={{ display: 'none' }}
           />
           {imgFile ? (
-            <S.ImgPreview src={imgFile} />
+            <S.ImagePreview src={imgFile} />
           ) : (
-            <S.ImageText>표지 이미지를 선택해주세요.</S.ImageText>
+            <S.ImageText placeholder="표지 이미지를 선택해주세요." disabled />
           )}
         </S.ImageWrapper>
-        <S.Content placeholder="자신의 생각을 적어보세요" />
+        {/* 내용 */}
+        <S.Content
+          ref={contentRef}
+          value={content}
+          onChange={onChangeContent}
+          placeholder="자신의 생각을 적어보세요"
+        />
+        {/* 푸터 */}
+        <S.Footer>
+          <S.ExitButton>
+            <ExitIcon />
+            나가기
+          </S.ExitButton>
+          <BasicButton color="positive" fontSize={18} width={110} height={40}>
+            등록하기
+          </BasicButton>
+        </S.Footer>
       </S.Wrapper>
     </S.Root>
   );

--- a/src/pages/ScrapWritePage/style.ts
+++ b/src/pages/ScrapWritePage/style.ts
@@ -79,8 +79,8 @@ const ArrowButton = styled.div`
 `;
 
 const Title = styled.textarea`
-  margin: 20px 0px;
-  font-size: ${({ theme }) => theme.TEXT_SIZE['text-32']};
+  margin: 30px 0px;
+  font-size: ${({ theme }) => theme.TEXT_SIZE['text-34']};
   width: 100%;
 `;
 
@@ -125,7 +125,7 @@ const Content = styled.textarea`
   padding: 20px 0px;
   width: 100%;
   min-height: 500px;
-  font-size: ${({ theme }) => theme.TEXT_SIZE['text-14']};
+  font-size: ${({ theme }) => theme.TEXT_SIZE['text-16']};
 `;
 
 const Footer = styled.div`

--- a/src/pages/ScrapWritePage/style.ts
+++ b/src/pages/ScrapWritePage/style.ts
@@ -85,13 +85,21 @@ const Title = styled.textarea`
 `;
 
 const LinkWrapper = styled.div`
+  width: 100%;
   ${flexCenter}
   justify-content: start;
+  align-items: start;
   margin-top: 26px;
 `;
 
+const LinkColumnWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding-left: 8px;
+`;
+
 const Link = styled.input`
-  margin-left: 8px;
   flex: 1;
   font-size: ${({ theme }) => theme.TEXT_SIZE['text-14']};
 `;
@@ -161,6 +169,7 @@ export const S = {
   ArrowButton,
   Title,
   LinkWrapper,
+  LinkColumnWrapper,
   Link,
   ImageWrapper,
   ImageButton,

--- a/src/pages/ScrapWritePage/style.ts
+++ b/src/pages/ScrapWritePage/style.ts
@@ -2,11 +2,36 @@ import { styled } from 'styled-components';
 import { flexCenter } from './../../style/common';
 
 const Root = styled.div`
-  ${flexCenter}
+  width: 100%;
+  min-height: calc(100vh - 60px);
+  display: flex;
+  justify-content: center;
+
+  /* 스크롤 숨기기 */
+  textarea {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+
+    &::-webkit-scrollbar {
+      display: none; /* Chrome, Safari, Opera*/
+    }
+  }
+
+  textarea,
+  input {
+    color: inherit;
+    background: inherit;
+    font-family: inherit;
+  }
 `;
 
 const Wrapper = styled.div`
-  width: 900px;
+  min-width: 300px;
+  max-width: 900px;
+  width: 80%;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 100px;
 `;
 
 const CategoryDropdown = styled.div`
@@ -16,7 +41,7 @@ const CategoryDropdown = styled.div`
   height: 30px;
   padding: 0px 10px;
   margin-top: 50px;
-  ${flexCenter}; /* justify-content: space-around; */
+  ${flexCenter};
   &:hover {
     cursor: pointer;
   }
@@ -26,7 +51,7 @@ const CategoryDropdown = styled.div`
 const CategoryList = styled.div`
   position: absolute;
   width: inherit;
-  top: 86px;
+  transform: translateY(calc(50% + 20px));
   box-shadow: ${({ theme }) => theme.boxShadow};
   color: ${({ theme }) => theme.COLOR.lightGrey};
   border-radius: 4px;
@@ -53,9 +78,10 @@ const ArrowButton = styled.div`
   margin-left: auto;
 `;
 
-const Title = styled.input`
+const Title = styled.textarea`
   margin: 20px 0px;
   font-size: ${({ theme }) => theme.TEXT_SIZE['text-32']};
+  width: 100%;
 `;
 
 const LinkWrapper = styled.div`
@@ -66,14 +92,15 @@ const LinkWrapper = styled.div`
 
 const Link = styled.input`
   margin-left: 8px;
-  width: 600px;
+  flex: 1;
   font-size: ${({ theme }) => theme.TEXT_SIZE['text-14']};
 `;
 
 const ImageWrapper = styled.div`
   display: flex;
   justify-content: start;
-  margin-top: 6px;
+  margin-top: 10px;
+  color: ${({ theme }) => theme.COLOR.lightGrey};
 `;
 
 const ImageButton = styled.label`
@@ -83,11 +110,12 @@ const ImageButton = styled.label`
   }
 `;
 
-const ImageText = styled.div`
+const ImageText = styled.input`
+  width: 200px;
   font-size: ${({ theme }) => theme.TEXT_SIZE['text-14']};
 `;
 
-const ImgPreview = styled.img`
+const ImagePreview = styled.img`
   width: 500px;
 `;
 
@@ -96,9 +124,31 @@ const Content = styled.textarea`
   margin-top: 30px;
   padding: 20px 0px;
   width: 100%;
-  height: 400px;
+  min-height: 500px;
   font-size: ${({ theme }) => theme.TEXT_SIZE['text-14']};
-  font-family: inherit;
+`;
+
+const Footer = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 100px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0px 30px;
+`;
+
+const ExitButton = styled.button`
+  display: flex;
+  align-items: center;
+  color: ${({ theme }) => theme.COLOR.darkGrey};
+  font-size: ${({ theme }) => theme.TEXT_SIZE['text-18']};
+  margin-right: 20px;
+  svg > path {
+    stroke: ${({ theme }) => theme.COLOR.darkGrey};
+  }
 `;
 
 export const S = {
@@ -115,6 +165,8 @@ export const S = {
   ImageWrapper,
   ImageButton,
   ImageText,
-  ImgPreview,
-  Content
+  ImagePreview,
+  Content,
+  Footer,
+  ExitButton
 };

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -29,9 +29,12 @@ const router = createBrowserRouter([
 
       { element: <CategoryPage />, path: '/category/:categoryId' },
       { element: <SearchPage />, path: '/search' },
-      { element: <DetailPage />, path: '/detail' },
-      { element: <ScrapWritePage />, path: '/scrap-write' }
+      { element: <DetailPage />, path: '/detail' }
     ]
+  },
+  {
+    element: <HeaderLayout isWriteButton={false} />,
+    children: [{ element: <ScrapWritePage />, path: '/scrap-write' }]
   }
 ]);
 

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -29,10 +29,10 @@ const router = createBrowserRouter([
 
       { element: <CategoryPage />, path: '/category/:categoryId' },
       { element: <SearchPage />, path: '/search' },
-      { element: <DetailPage />, path: '/detail' }
+      { element: <DetailPage />, path: '/detail' },
+      { element: <ScrapWritePage />, path: '/scrap-write' }
     ]
-  },
-  { element: <ScrapWritePage />, path: '/scrap-write' }
+  }
 ]);
 
 export default router;


### PR DESCRIPTION
## #️⃣연관된 이슈

#11 

## 📝작업 내용

- tagCreator 줄바꿈 가능하도록 변경

-  스크랩 작성 페이지 완성 (푸터와 미리보기 추가)

-  스크랩 작성 페이지에 헤더 넣기 (글쓰기 버튼은 숨기기)

- recoil persist 시키기
