### PR TITLE
프라이빗 라우트, Auth 페이지 생성, 메인 페이지와 유저 api 연결 작업 중

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -2,6 +2,14 @@ import axios, { AxiosError } from 'axios';
 import { NETWORK } from 'constants/Api';
 import { postNewToken } from 'apis/member';
 
+export const axiosInstanceWithoutToken = axios.create({
+  baseURL: process.env.REACT_APP_BACK_URL,
+  timeout: NETWORK.TIMEOUT,
+  headers: {
+    'Content-Type': 'application/json; charset=utf-8'
+  }
+});
+
 export const axiosInstance = axios.create({
   baseURL: process.env.REACT_APP_BACK_URL,
   timeout: NETWORK.TIMEOUT,
@@ -52,13 +60,19 @@ axiosInstance.interceptors.response.use(
   async (error: AxiosError) => {
     const originalRequest = error.config!;
     //인증 문제
-    if (error?.response?.status === 401 && !isRefreshing) {
+    if (error?.response?.status == 401 && !isRefreshing) {
       isRefreshing = true;
       const data = await postNewToken();
+      console.log(data);
       if (data) {
+        console.log('재발급');
+        localStorage.removeItem('papersToken');
+        localStorage.removeItem('nickname');
         localStorage.setItem('papersToken', data.accessToken);
         localStorage.setItem('nickname', data.nickname);
-        originalRequest.headers['Authorization'] = `Bearer ${data.accessToken}`;
+        originalRequest.headers[
+          'Authorization'
+        ] = `Bearer ${localStorage.getItem('paparsToken')}`;
         const originalResponse = await axios.request(originalRequest);
         return originalResponse.data;
       } else {

--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -6,16 +6,16 @@ export type NewCommentType = {
   commentContent: string;
 };
 export const postNewComment = async (commentInfo: NewCommentType) => {
-  const { data } = await axiosInstance.post('/comments', {
+  const res = await axiosInstance.post('/comments', {
     ...commentInfo
   });
-  return data;
+  return res;
 };
 
 //댓글 삭제
 export const deleteComment = async (commentId: number) => {
-  const { data } = await axiosInstance.delete(`/comments/${commentId}`);
-  return data;
+  const res = await axiosInstance.delete(`/comments/${commentId}`);
+  return res;
 };
 
 //스크랩의 댓글 목록 조회
@@ -30,16 +30,16 @@ export type NewReplyType = {
 };
 //대댓글 작성
 export const postNewReply = async (replyInfo: NewReplyType) => {
-  const data = await axiosInstance.post('/replys', {
+  const res = await axiosInstance.post('/replys', {
     ...replyInfo
   });
-  return data;
+  return res;
 };
 
 //대댓글 삭제
 export const deleteReply = async (replyId: number) => {
-  const data = await axiosInstance.delete(`/replyies/${replyId}`);
-  return data;
+  const res = await axiosInstance.delete(`/replyies/${replyId}`);
+  return res;
 };
 
 //댓글의 대댓글 목록 조회

--- a/src/apis/follow.ts
+++ b/src/apis/follow.ts
@@ -23,3 +23,8 @@ export const getFollowerList = async () => {
   const { data } = await axiosInstance.get('/members/followers');
   return data;
 };
+
+export const getCurrentFollowing = async (nickname: string) => {
+  const { data } = await axiosInstance.get(`/follows/isFollower/${nickname}`);
+  return data;
+};

--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -42,9 +42,11 @@ export const postSameName = async (nickname: string) => {
 
 //회원 정보 조회
 export const postOtherUserInfo = async (nickname: string) => {
+  console.log('nickname', nickname);
   const { data } = await axiosInstance.post('/members/search', {
     nickname
   });
+  console.log('data', data);
   return data;
 };
 

--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { axiosInstance } from './axiosInstance';
+import { UserInfoType } from '../hooks/apis/member';
 
 //회원 가입
 export const postLogin = async (code: string) => {
@@ -41,11 +42,13 @@ export const postSameName = async (nickname: string) => {
 };
 
 //회원 정보 조회
-export const postOtherUserInfo = async (nickname: string) => {
-  console.log('nickname', nickname);
-  const { data } = await axiosInstance.post('/members/search', {
-    nickname
-  });
+export const getOtherUserInfo = async (nickname: string) => {
+  const { data } = await axios.get<UserInfoType>(
+    `http://3.37.102.113:8080/members/search/${nickname}`,
+    {
+      headers: { 'Content-Type': 'application/json; charset=utf-8' }
+    }
+  );
   console.log('data', data);
   return data;
 };

--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { axiosInstance } from './axiosInstance';
+import { axiosInstance, axiosInstanceWithoutToken } from './axiosInstance';
 import { UserInfoType } from '../hooks/apis/member';
 
 //회원 가입
@@ -24,14 +24,13 @@ type NewTokenResponseType = {
   nickname: string;
 };
 
-export const postNewToken = async (): Promise<NewTokenResponseType> => {
-  const { data } = await axiosInstance.post('/auth/reissue');
+export const postNewToken = async () => {
+  const data: NewTokenResponseType = await axiosInstance.get('/auth/reissue');
   return data;
 };
 
 //닉네임 중복 조회
 export const postSameName = async (nickname: string) => {
-  console.log('이름중복', nickname);
   const { data } = await axiosInstance.post<boolean>(
     '/members/nickname/isExist',
     {
@@ -49,7 +48,6 @@ export const getOtherUserInfo = async (nickname: string) => {
       headers: { 'Content-Type': 'application/json; charset=utf-8' }
     }
   );
-  console.log('data', data);
   return data;
 };
 
@@ -60,6 +58,7 @@ export type ProfileType = {
   };
   profileImg: File;
 };
+
 //프로필 설정
 export const postMyProfile = async (profileInfo: FormData) => {
   console.log(profileInfo);
@@ -71,4 +70,8 @@ export const postMyProfile = async (profileInfo: FormData) => {
   return data;
 };
 
-//회원별 스크랩 조회✅ 수정 필요
+//랜덤 회원 리스트 조회
+export const getRecommendUsers = async () => {
+  const { data } = await axiosInstanceWithoutToken('/members/random-list');
+  return data;
+};

--- a/src/apis/scraps.ts
+++ b/src/apis/scraps.ts
@@ -1,5 +1,5 @@
 //스크랩 삭제
-import { axiosInstance } from './axiosInstance';
+import { axiosInstance, axiosInstanceWithoutToken } from './axiosInstance';
 import { CategoryKeyType, SearchRangeKeyType } from '../constants/Category';
 
 export type OneNewScrapType = {
@@ -44,15 +44,18 @@ export const deleteScrap = async (scrapId: number) => {
   return data;
 };
 
-//스크랩 조회
+//스크랩 디테일 조회
 export const getScrapDetail = async (scrapId: number) => {
   const { data } = await axiosInstance.get(`/scraps/${scrapId}`);
   return data;
 };
 
 //내 추천 스크랩 보기
-export const getRecommentScrapList = async () => {
-  const { data } = await axiosInstance.get(`/scraps/recommend`);
+export const getRecommendScrapList = async () => {
+  const { data } = await axiosInstanceWithoutToken.get(
+    `/scraps/recommend?page=1`
+  );
+  console.log('dagta', data);
   return data;
 };
 
@@ -69,5 +72,13 @@ export const getSearchScrap = async (searchInfo: SearchScrapType) => {
       ...searchInfo
     }
   });
+  return data;
+};
+
+//회원별 스크랩 조회
+export const getMyScraps = async (nickname: string) => {
+  const { data } = await axiosInstanceWithoutToken(
+    `/members/${nickname}/scraps`
+  );
   return data;
 };

--- a/src/atom/user.tsx
+++ b/src/atom/user.tsx
@@ -1,0 +1,6 @@
+// import { atom } from 'recoil';
+//
+// export const userState = atom({
+//   key: 'user',
+//   default: {}
+// });

--- a/src/atom/user.tsx
+++ b/src/atom/user.tsx
@@ -1,6 +1,0 @@
-// import { atom } from 'recoil';
-//
-// export const userState = atom({
-//   key: 'user',
-//   default: {}
-// });

--- a/src/components/FolderPage/MyMenu/MyMenu.tsx
+++ b/src/components/FolderPage/MyMenu/MyMenu.tsx
@@ -4,13 +4,15 @@ import { ReactComponent as HeartIcon } from 'asset/navBar/heart.svg';
 import { ReactComponent as LogoutIcon } from 'asset/navBar/logout.svg';
 import { M } from './style';
 import { useNavigate } from 'react-router-dom';
+import { LocalStorage } from '../../../utils/localStorage';
 
 const MyMenu = () => {
   const navigate = useNavigate();
+  const nickname = LocalStorage.getNickname();
   return (
     <>
       <M.MenuWrapper>
-        <M.OneMenuWrapper onClick={() => navigate('/folder/나는%20고양이다')}>
+        <M.OneMenuWrapper onClick={() => navigate(`/folder/%{nickname}`)}>
           <M.MenuIcon>
             <FolderIcon />
           </M.MenuIcon>

--- a/src/components/FolderPage/ProfileBox/ProfileBox.tsx
+++ b/src/components/FolderPage/ProfileBox/ProfileBox.tsx
@@ -1,10 +1,12 @@
 import { S } from './style';
 import React from 'react';
 import BasicButton from '../../_common/BasicButton/BasicButton';
-import CircleIcon from '../../_common/CircleBox/CircleBox';
 import { useRecoilState } from 'recoil';
 import { userModalAtom } from '../../../atom/modal';
 import UserModal from '../../Modal/UserModal/UserModal';
+import { LocalStorage } from '../../../utils/localStorage';
+import { useUserInfoQuery } from '../../../hooks/apis/member';
+import CircleIcon from '../../_common/CircleBox/CircleBox';
 
 export type ProfileProps = {
   userName: string;
@@ -15,24 +17,27 @@ export type ProfileProps = {
 const ProfileBox = ({ userName, userDetail, imgUrl }: ProfileProps) => {
   const [userModalState, setUserModalState] = useRecoilState(userModalAtom);
 
+  const nickname = LocalStorage.getNickname()!;
+  const userInfo = useUserInfoQuery(nickname);
+
   return (
     <>
       {userModalState && (
         <UserModal
-          userName={userName}
-          userDetail={userDetail}
-          imgUrl={imgUrl}
+          userName={userInfo?.nickname || ''}
+          userDetail={userInfo?.introduce || ''}
+          imgUrl={userInfo?.profileImgUrl || ''}
         />
       )}
 
       <S.ProfileWrapper>
         <S.FlexWrapperColumn>
           <S.UserProfile>
-            <CircleIcon size="big" imgUrl={imgUrl} />
+            <CircleIcon size="big" imgUrl={userInfo?.profileImgUrl} />
           </S.UserProfile>
           <S.UserInfo>
-            <S.UserName>{userName}</S.UserName>
-            <S.UserDetail>{userDetail}</S.UserDetail>
+            <S.UserName>{userInfo?.nickname}</S.UserName>
+            <S.UserDetail>{userInfo?.introduce}</S.UserDetail>
             <BasicButton
               color={'blue'}
               fontSize={14}

--- a/src/components/FolderPage/ProfileBox/ProfileBox.tsx
+++ b/src/components/FolderPage/ProfileBox/ProfileBox.tsx
@@ -22,14 +22,6 @@ const ProfileBox = ({ userName, userDetail, imgUrl }: ProfileProps) => {
 
   return (
     <>
-      {userModalState && (
-        <UserModal
-          userName={userInfo?.nickname || ''}
-          userDetail={userInfo?.introduce || ''}
-          imgUrl={userInfo?.profileImgUrl || ''}
-        />
-      )}
-
       <S.ProfileWrapper>
         <S.FlexWrapperColumn>
           <S.UserProfile>

--- a/src/components/Header/Header/Header.tsx
+++ b/src/components/Header/Header/Header.tsx
@@ -7,29 +7,19 @@ import { S } from './style';
 import CircleIcon from '../../_common/CircleBox/CircleBox';
 import { useNavigate } from 'react-router-dom';
 import ModeToggleButton from '../ModeToggleButton/ModeToggleButton';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { modeState } from '../../../atom/mode';
-import { useUserDetailInfoMutation } from '../../../hooks/apis/member';
+import { UserInfoType } from '../../../hooks/apis/member';
 
 export type HeaderProps = {
   isWriteButton?: boolean;
+  userInfo: UserInfoType | undefined;
 };
 
-const Header = ({ isWriteButton = true }: HeaderProps) => {
+const Header = ({ isWriteButton = true, userInfo }: HeaderProps) => {
   const navigate = useNavigate();
   const mode = useRecoilValue(modeState);
-  const { postGetUserInfoMutate } = useUserDetailInfoMutation();
-
-  useEffect(() => {
-    const nickname = localStorage.getItem('nickname');
-    if (nickname) {
-      const data = postGetUserInfoMutate(nickname);
-      console.log('daa', data);
-    }
-
-    console.log();
-  }, []);
 
   return (
     <S.Wrapper>
@@ -56,10 +46,25 @@ const Header = ({ isWriteButton = true }: HeaderProps) => {
           </BasicButton>
         )}
       </S.BasicButtonWrapper>
-
-      <S.ProfileImgWrapper onClick={() => navigate('/folder/나는 고양이다')}>
-        <CircleIcon size="small" imgUrl="" />
-      </S.ProfileImgWrapper>
+      {userInfo ? (
+        <S.ProfileImgWrapper
+          onClick={() => navigate(`/folder/${userInfo.nickname}`)}
+        >
+          <CircleIcon size="small" imgUrl={''} />
+        </S.ProfileImgWrapper>
+      ) : (
+        <BasicButton
+          color={'grey'}
+          fontSize={12}
+          width={60}
+          height={35}
+          onClick={() => {
+            navigate('/login');
+          }}
+        >
+          로그인
+        </BasicButton>
+      )}
     </S.Wrapper>
   );
 };

--- a/src/components/Header/Header/Header.tsx
+++ b/src/components/Header/Header/Header.tsx
@@ -7,9 +7,10 @@ import { S } from './style';
 import CircleIcon from '../../_common/CircleBox/CircleBox';
 import { useNavigate } from 'react-router-dom';
 import ModeToggleButton from '../ModeToggleButton/ModeToggleButton';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import { modeState } from '../../../atom/mode';
+import { useUserDetailInfoMutation } from '../../../hooks/apis/member';
 
 export type HeaderProps = {
   isWriteButton?: boolean;
@@ -18,6 +19,17 @@ export type HeaderProps = {
 const Header = ({ isWriteButton = true }: HeaderProps) => {
   const navigate = useNavigate();
   const mode = useRecoilValue(modeState);
+  const { postGetUserInfoMutate } = useUserDetailInfoMutation();
+
+  useEffect(() => {
+    const nickname = localStorage.getItem('nickname');
+    if (nickname) {
+      const data = postGetUserInfoMutate(nickname);
+      console.log('daa', data);
+    }
+
+    console.log();
+  }, []);
 
   return (
     <S.Wrapper>

--- a/src/components/Modal/UserModal/UserModal.tsx
+++ b/src/components/Modal/UserModal/UserModal.tsx
@@ -43,7 +43,9 @@ const UserModal = ({
 
   const inputRef = useRef<HTMLInputElement>(null);
   //닉네임 중복 검사
-  const onSubmitNickname = () => {
+  const onSubmitNickname = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
     postSameNameAction(name);
     if (hasSameName) {
       setErrorMessage('중복된 이름이 있습니다.');
@@ -66,7 +68,7 @@ const UserModal = ({
   };
 
   //프로필 변경 제출
-  const onSubmitProfile = () => {
+  const onSubmitProfile = (e: React.MouseEvent<HTMLButtonElement>) => {
     const dto = {
       nickname: name,
       introduce: detail
@@ -141,7 +143,6 @@ const UserModal = ({
                 중복 확인
               </BasicButton>
               <S.ErrorMsg>{errorMessage}</S.ErrorMsg>
-              {/*닉네임 중복 검사*/}
             </S.UserNameBox>
             <TextArea
               type={'text'}

--- a/src/components/Modal/UserModal/UserModal.tsx
+++ b/src/components/Modal/UserModal/UserModal.tsx
@@ -34,7 +34,7 @@ const UserModal = ({ imgUrl, userName, userDetail }: ProfileProps) => {
 
   const inputRef = useRef<HTMLInputElement>(null);
   //닉네임 중복 검사
-  const onSubmitNickname = async () => {
+  const onSubmitNickname = () => {
     postSameNameAction(name);
     if (hasSameName) {
       setErrorMessage('중복된 이름이 있습니다.');

--- a/src/components/Modal/UserModal/UserModal.tsx
+++ b/src/components/Modal/UserModal/UserModal.tsx
@@ -11,10 +11,17 @@ import InputBox from '../../_common/InputBox/InputBox';
 import BasicButton from '../../_common/BasicButton/BasicButton';
 import TextArea from '../../_common/TextArea/TextArea';
 import useInputs from '../../../hooks/useInputs';
-import { ProfileProps } from '../../FolderPage/ProfileBox/ProfileBox';
 import { userModalAtom } from '../../../atom/modal';
 
-const UserModal = ({ imgUrl, userName, userDetail }: ProfileProps) => {
+const UserModal = ({
+  imgUrl,
+  userName,
+  userDetail
+}: {
+  imgUrl: string | null;
+  userName: string;
+  userDetail: string;
+}) => {
   const setUserModalOpen = useSetRecoilState(userModalAtom);
 
   const { values, onChange } = useInputs({
@@ -24,7 +31,9 @@ const UserModal = ({ imgUrl, userName, userDetail }: ProfileProps) => {
 
   const { name, detail } = values;
 
-  const [profileImg, setProfileImg] = useState<string>(imgUrl);
+  const [profileImg, setProfileImg] = useState<string | null | undefined>(
+    imgUrl
+  );
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   //이름 중복 검사
@@ -64,7 +73,10 @@ const UserModal = ({ imgUrl, userName, userDetail }: ProfileProps) => {
     };
 
     const formData = new FormData();
-    formData.append('profileImg', profileImg);
+    //프로필 이미지가 있을 때만 제출
+    if (profileImg) {
+      formData.append('profileImg', profileImg);
+    }
     formData.append('dto', JSON.stringify(dto));
     postProfileMutate(formData);
   };

--- a/src/components/_common/CircleBox/CircleBox.tsx
+++ b/src/components/_common/CircleBox/CircleBox.tsx
@@ -4,7 +4,7 @@ import { ReactElement } from 'react';
 type CircleSize = 'big' | 'medium' | 'small' | 'verySmall';
 
 export type CircleIconType = {
-  imgUrl: string;
+  imgUrl: string | null | undefined;
   size: CircleSize;
   children?: ReactElement;
   onClick?: () => void;

--- a/src/components/_common/ScrapCard/ScrapCard.tsx
+++ b/src/components/_common/ScrapCard/ScrapCard.tsx
@@ -5,7 +5,6 @@ import { ReactComponent as DarkHeartIcon } from 'asset/scrapCard/darkHeart.svg';
 import { useRecoilValue } from 'recoil';
 import { modeState } from 'atom/mode';
 import { useNavigate } from 'react-router-dom';
-import LinkPreview from 'components/_common/LinkPreview/LinkPreview';
 
 export type ScrapCardProps = {
   width: number;
@@ -29,7 +28,7 @@ const ScrapCard = (props: ScrapCardProps) => {
       $width={props.width}
     >
       <S.LinkBox to={props.link} target="_blank">
-        <LinkPreview url={props.link} size={'small'} />
+        {/*<LinkPreview url={props.link} size={'small'} />*/}
       </S.LinkBox>
       <S.ScrapBox>
         <S.ImageBox>

--- a/src/hooks/apis/comment.ts
+++ b/src/hooks/apis/comment.ts
@@ -1,21 +1,20 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
-  NewCommentType,
   deleteComment,
-  postNewComment,
-  getCommentList,
-  NewReplyType,
-  postNewReply,
   deleteReply,
-  getReplyList
+  getCommentList,
+  getReplyList,
+  NewCommentType,
+  NewReplyType,
+  postNewComment,
+  postNewReply
 } from 'apis/comment';
 import { AxiosError } from 'axios';
-import { AxiosResponseType } from 'constants/Api';
 
 //댓글 작성 mutation
 export const usePostNewCommentMutation = () => {
   const { mutate: postCommentAction } = useMutation<
-    AxiosResponseType,
+    any,
     AxiosError,
     NewCommentType
   >({
@@ -26,11 +25,7 @@ export const usePostNewCommentMutation = () => {
 
 //댓글 삭제
 export const useDeleteCommentMutation = () => {
-  const { mutate: deleteCommentAction } = useMutation<
-    AxiosResponseType,
-    AxiosError,
-    number
-  >({
+  const { mutate: deleteCommentAction } = useMutation<any, AxiosError, number>({
     mutationFn: (commentId: number) => deleteComment(commentId)
   });
   return { deleteCommentAction };

--- a/src/hooks/apis/member.ts
+++ b/src/hooks/apis/member.ts
@@ -1,8 +1,8 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import {
+  getOtherUserInfo,
   postMyProfile,
   postNewToken,
-  postOtherUserInfo,
   postSameName
 } from 'apis/member';
 import { AxiosError } from 'axios';
@@ -27,16 +27,23 @@ export const useSameNameMutation = () => {
   return { postSameNameAction, data };
 };
 
+export type UserInfoType = {
+  defaultFolderId: number;
+  email: string;
+  introduce: string | null;
+  nickname: string | null;
+  profileImgUrl: string | null;
+};
+
 //회원 정보 조회
-export const useUserDetailInfoMutation = () => {
-  const { mutate: postGetUserInfoMutate } = useMutation<
-    boolean,
-    AxiosError,
-    string
-  >({
-    mutationFn: (nickname: string) => postOtherUserInfo(nickname)
+export const useUserInfoQuery = (nickname: string) => {
+  const { data: userInfo } = useQuery({
+    queryKey: ['userInfo', nickname],
+    queryFn: () => getOtherUserInfo(nickname),
+    enabled: !!nickname
   });
-  return { postGetUserInfoMutate };
+
+  return userInfo;
 };
 
 //프로필 설정

--- a/src/hooks/apis/member.ts
+++ b/src/hooks/apis/member.ts
@@ -1,8 +1,8 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import {
   postMyProfile,
-  postOtherUserInfo,
   postNewToken,
+  postOtherUserInfo,
   postSameName
 } from 'apis/member';
 import { AxiosError } from 'axios';

--- a/src/hooks/apis/member.ts
+++ b/src/hooks/apis/member.ts
@@ -3,8 +3,10 @@ import {
   getOtherUserInfo,
   postMyProfile,
   postNewToken,
-  postSameName
+  postSameName,
+  getRecommendUsers
 } from 'apis/member';
+
 import { AxiosError } from 'axios';
 
 //토큰 재발급 mutation ✅백엔드 수정 필요 (POST가 아니라 GET 메소드여야 할듯.)
@@ -56,4 +58,13 @@ export const usePostProfile = () => {
     mutationFn: (profileInfo: FormData) => postMyProfile(profileInfo)
   });
   return { postProfileMutate };
+};
+
+export const useRecommendUsersQuery = () => {
+  const { data } = useQuery({
+    queryKey: ['userList'],
+    queryFn: () => getRecommendUsers()
+  });
+
+  return data;
 };

--- a/src/hooks/apis/scrap.ts
+++ b/src/hooks/apis/scrap.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   deleteScrap,
-  getRecommentScrapList,
+  getRecommendScrapList,
   getScrapDetail,
   getSearchScrap,
   OneNewScrapType,
@@ -65,7 +65,7 @@ export const useGetScrapDetailQuery = (scrapId: number) => {
 export const useRecommendScrapQuery = () => {
   const { data } = useQuery({
     queryKey: ['recommendScrap'],
-    queryFn: () => getRecommentScrapList()
+    queryFn: () => getRecommendScrapList()
   });
   return data;
 };

--- a/src/layout/ModalLayout/ModalLayout.tsx
+++ b/src/layout/ModalLayout/ModalLayout.tsx
@@ -1,14 +1,18 @@
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { Outlet, useParams } from 'react-router-dom';
 import { useBodyScrollLock } from '../../hooks/useScrollLock';
 import { useEffect } from 'react';
 import { S } from './style';
-import { folderModalAtom } from '../../atom/modal';
+import { folderModalAtom, userModalAtom } from '../../atom/modal';
 import { folderMock } from '../../mock/userMock';
 import FolderModal from '../../components/Modal/FolderModal/FolderModal';
+import { LocalStorage } from 'utils/localStorage';
+import { useUserInfoQuery } from 'hooks/apis/member';
+import UserModal from 'components/Modal/UserModal/UserModal';
 
 const ModalLayout = () => {
   const folderModal = useRecoilValue(folderModalAtom);
+  const userModal = useRecoilState(userModalAtom);
 
   const { lockScroll, openScroll } = useBodyScrollLock();
   const params = useParams();
@@ -24,9 +28,21 @@ const ModalLayout = () => {
     }
   }, [folderModal.open]);
 
+  const [userModalState, setUserModalState] = useRecoilState(userModalAtom);
+
+  const nickname = LocalStorage.getNickname()!;
+  const userInfo = useUserInfoQuery(nickname);
+
   return (
     <S.Wrapper isScrollAble={!folderModal.open}>
       <S.ModalWrapper>
+        {userModalState && (
+          <UserModal
+            userName={userInfo?.nickname || ''}
+            userDetail={userInfo?.introduce || ''}
+            imgUrl={userInfo?.profileImgUrl || ''}
+          />
+        )}
         {folderModal.open && <FolderModal folderList={folderList} />}
       </S.ModalWrapper>
       <Outlet />

--- a/src/layout/headerLayout/HeaderLayout.tsx
+++ b/src/layout/headerLayout/HeaderLayout.tsx
@@ -9,10 +9,6 @@ const HeaderLayout = () => {
   const isWriteButton = true;
   const nickname = LocalStorage.getNickname()!;
   const userInfo = useUserInfoQuery(nickname);
-
-  //유저 정보 가져오기
-  // const userInfo: any = postGetUserInfoMutate(LocalStorage.getNickname()!);
-
   return (
     <S.Wrapper>
       <Header isWriteButton={isWriteButton} userInfo={userInfo} />

--- a/src/layout/headerLayout/HeaderLayout.tsx
+++ b/src/layout/headerLayout/HeaderLayout.tsx
@@ -1,12 +1,21 @@
-import Header, { HeaderProps } from 'components/Header/Header/Header';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { S } from './style';
+import { useUserInfoQuery } from '../../hooks/apis/member';
+import { LocalStorage } from '../../utils/localStorage';
+import Header from '../../components/Header/Header/Header';
 
-const HeaderLayout = ({ isWriteButton = true }: HeaderProps) => {
+const HeaderLayout = () => {
+  const isWriteButton = true;
+  const nickname = LocalStorage.getNickname()!;
+  const userInfo = useUserInfoQuery(nickname);
+
+  //유저 정보 가져오기
+  // const userInfo: any = postGetUserInfoMutate(LocalStorage.getNickname()!);
+
   return (
     <S.Wrapper>
-      <Header isWriteButton={isWriteButton} />
+      <Header isWriteButton={isWriteButton} userInfo={userInfo} />
       <S.ContentWrapper>
         <Outlet />
       </S.ContentWrapper>

--- a/src/layout/navbarLayout/NavbarLayout.tsx
+++ b/src/layout/navbarLayout/NavbarLayout.tsx
@@ -2,26 +2,29 @@ import { Outlet } from 'react-router-dom';
 import { ReactComponent as WriteIcon } from 'asset/_common/write.svg';
 import BasicButton from 'components/_common/BasicButton/BasicButton';
 import { S } from './style';
-import ProfileBox from 'components/FolderPage/ProfileBox/ProfileBox';
 import MyMenu from 'components/FolderPage/MyMenu/MyMenu';
-import { UserMock } from 'mock/userMock';
 import Header from 'components/Header/Header/Header';
 import React from 'react';
+import { LocalStorage } from '../../utils/localStorage';
+import { useUserInfoQuery } from '../../hooks/apis/member';
+import ProfileBox from '../../components/FolderPage/ProfileBox/ProfileBox';
 
 const NavbarLayout = () => {
-  const { nickname, userDetail, imgUrl } = UserMock;
   const isMine = true;
+
+  const nickname = LocalStorage.getNickname()!;
+  const userInfo = useUserInfoQuery(nickname);
 
   return (
     <S.Wrapper>
-      <Header />
+      <Header userInfo={userInfo} />
       <S.NavBarWrapper>
         <S.FlexWrapper>
           {/*프로필 소개글*/}
           <ProfileBox
-            userName={nickname}
-            userDetail={userDetail}
-            imgUrl={imgUrl}
+            imgUrl={userInfo?.profileImgUrl || ''}
+            userName={userInfo?.nickname || ''}
+            userDetail={userInfo?.introduce || ''}
           />
           {isMine && <MyMenu />}
           <S.ScrapButtonWrapper>

--- a/src/layout/navbarLayout/NavbarLayout.tsx
+++ b/src/layout/navbarLayout/NavbarLayout.tsx
@@ -4,13 +4,22 @@ import BasicButton from 'components/_common/BasicButton/BasicButton';
 import { S } from './style';
 import MyMenu from 'components/FolderPage/MyMenu/MyMenu';
 import Header from 'components/Header/Header/Header';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { LocalStorage } from '../../utils/localStorage';
 import { useUserInfoQuery } from '../../hooks/apis/member';
 import ProfileBox from '../../components/FolderPage/ProfileBox/ProfileBox';
+import { userModalAtom } from '../../atom/modal';
+import { useRecoilState } from 'recoil';
 
 const NavbarLayout = () => {
-  const isMine = true;
+  const [userModalOpen, setUserModalOpen] = useRecoilState(userModalAtom);
+  const [isMine, setIsMine] = useState(false);
+
+  useEffect(() => {
+    if (LocalStorage.getNickname() == nickname) {
+      setIsMine(true);
+    }
+  }, []);
 
   const nickname = LocalStorage.getNickname()!;
   const userInfo = useUserInfoQuery(nickname);

--- a/src/mock/postMock.tsx
+++ b/src/mock/postMock.tsx
@@ -10,7 +10,8 @@ export const OnePostMock: OneScrapType = {
   scrapLink: 'https://despiteallthat.tistory.com/243',
   imgUrl:
     'https://ak-d.tripcdn.com/images/1mj1c12000bnc2cdm5451_C_800_600_R5.jpg_.webp?proc=autoorient',
-  writerInfo: UserMock,
+  writerNickname: '나는 고양이다',
+  writerProfile: '',
   CreatedAt: new Date(),
   tags: [
     {

--- a/src/pages/AuthPage/AuthPage.tsx
+++ b/src/pages/AuthPage/AuthPage.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { postLogin } from '../../apis/member';
+import { useNavigate } from 'react-router-dom';
+
+const AuthPage = () => {
+  const navigate = useNavigate();
+  // 구글 로그인 처리
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search); //구글 로그인 redirect URI
+    const code = searchParams.get('code'); //URI의 파라미터에서 code를 추출
+    if (code) {
+      login(code); //추출한 code로 백엔드에 로그인 api 요청
+    }
+  }, []);
+  const [isFirst, setIsFirst] = useState<boolean>();
+
+  // 백엔드에 로그인 api 요청
+  const login = async (code: string) => {
+    try {
+      const data = await postLogin(code);
+      console.log('aaa', data);
+      if (data) {
+        data.isFirst && setIsFirst(true);
+        localStorage.setItem('papersToken', data.accessToken);
+        localStorage.setItem('nickname', data.nickname);
+        navigate('/?isFirst=true');
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  return <div>로그인 중입니다.</div>;
+};
+
+export default AuthPage;

--- a/src/pages/AuthPage/AuthPage.tsx
+++ b/src/pages/AuthPage/AuthPage.tsx
@@ -12,7 +12,6 @@ const AuthPage = () => {
       login(code); //추출한 code로 백엔드에 로그인 api 요청
     }
   }, []);
-  const [isFirst, setIsFirst] = useState<boolean>();
 
   // 백엔드에 로그인 api 요청
   const login = async (code: string) => {
@@ -20,10 +19,9 @@ const AuthPage = () => {
       const data = await postLogin(code);
       console.log('aaa', data);
       if (data) {
-        data.isFirst && setIsFirst(true);
         localStorage.setItem('papersToken', data.accessToken);
         localStorage.setItem('nickname', data.nickname);
-        navigate('/?isFirst=true');
+        navigate(`/?isFirst=${!data.isExist}`);
       }
     } catch (error) {
       console.log(error);

--- a/src/pages/CategoryPage/CategoryPage.tsx
+++ b/src/pages/CategoryPage/CategoryPage.tsx
@@ -21,7 +21,7 @@ const CategoryPage = () => {
               scrapContent,
               scrapLink,
               imgUrl,
-              writerInfo
+              writerNickname
             } = scrap;
             return (
               <>
@@ -34,7 +34,7 @@ const CategoryPage = () => {
                   title={scrapTitle}
                   content={scrapContent}
                   heartCnt={10}
-                  author={writerInfo.nickname}
+                  author={writerNickname}
                 />
               </>
             );

--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -8,7 +8,14 @@ import LinkPreview from '../../components/_common/LinkPreview/LinkPreview';
 import TagCreator from 'components/_common/TagCreator/TagCreator';
 
 const DetailPage = () => {
-  const { scrapTitle, scrapContent, writerInfo, imgUrl, tags } = OnePostMock;
+  const {
+    scrapTitle,
+    scrapContent,
+    writerNickname,
+    writerProfile,
+    imgUrl,
+    tags
+  } = OnePostMock;
 
   return (
     <S.Wrapper>
@@ -19,9 +26,9 @@ const DetailPage = () => {
       <S.Title>{scrapTitle}</S.Title>
       <TagCreator isCreator={false} tags={tags} />
       <S.UserInfoWrapper>
-        <CircleBox imgUrl={writerInfo.imgUrl} size={'small'} />
+        <CircleBox imgUrl={writerProfile} size={'small'} />
         <S.FlexColumnWrapper>
-          <S.Name>{writerInfo.nickname}</S.Name>
+          <S.Name>{writerNickname}</S.Name>
           <S.DateInfo>7일전</S.DateInfo>
         </S.FlexColumnWrapper>
       </S.UserInfoWrapper>

--- a/src/pages/FolderPage/FolderPage.tsx
+++ b/src/pages/FolderPage/FolderPage.tsx
@@ -4,19 +4,19 @@ import { OneFolderType } from '../../types/FolderType';
 import { folderMock } from '../../mock/userMock';
 import ScrapList from '../../components/FolderPage/ScrapList/ScrapList';
 import LineNavbar from '../../components/_common/LineNavbar/LineNavbar';
+import { useEffect, useState } from 'react';
+import { LocalStorage } from '../../utils/localStorage';
 
 const FolderPage = () => {
   const params = useParams();
   const nickname = params.nickname || '';
-  console.log('nickname', nickname);
-  // const [isMine, setIsMine] = useState(false);
+  const [isMine, setIsMine] = useState(false);
 
-  // useEffect(() => {
-  //   if (nickname == '나는 고양이다') {
-  //     setIsMine(true);
-  //   }
-  // }, []);
-  const isMine = false;
+  useEffect(() => {
+    if (LocalStorage.getNickname() == nickname) {
+      setIsMine(true);
+    }
+  }, []);
 
   const folderList: OneFolderType[] = folderMock;
 

--- a/src/pages/FolderPage/FolderPage.tsx
+++ b/src/pages/FolderPage/FolderPage.tsx
@@ -1,6 +1,5 @@
 import S from './style';
 import { useParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
 import { OneFolderType } from '../../types/FolderType';
 import { folderMock } from '../../mock/userMock';
 import ScrapList from '../../components/FolderPage/ScrapList/ScrapList';
@@ -8,14 +7,16 @@ import LineNavbar from '../../components/_common/LineNavbar/LineNavbar';
 
 const FolderPage = () => {
   const params = useParams();
-  const nickname = params.nickname;
-  const [isMine, setIsMine] = useState(false);
+  const nickname = params.nickname || '';
+  console.log('nickname', nickname);
+  // const [isMine, setIsMine] = useState(false);
 
-  useEffect(() => {
-    if (nickname == '나는 고양이다') {
-      setIsMine(true);
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (nickname == '나는 고양이다') {
+  //     setIsMine(true);
+  //   }
+  // }, []);
+  const isMine = false;
 
   const folderList: OneFolderType[] = folderMock;
 

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,10 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { S } from './style';
 import { ReactComponent as GoogleLoginButton } from 'asset/loginPage/googleLoginButton.svg';
-import { useGoogleLogin } from '@react-oauth/google';
 import { ReactComponent as LogoImg } from 'asset/_common/logoImg.svg';
 import { ReactComponent as BlackLogo } from 'asset/_common/logoBlack.svg';
-import { ReactComponent as WhiteLogo } from 'asset/_common/logoWhite.svg';
 import mainImage from 'asset/loginPage/mainImage.png';
 import searchBarImage from 'asset/loginPage/searchBarImage.png';
 import folderImage from 'asset/loginPage/folderImage.png';
@@ -25,8 +23,7 @@ const LoginPage = () => {
 
   // 구글 로그인 페이지로 리다이렉션 (구글 계정 고르는 페이지)
   const onGoogleLogin = () => {
-    window.location.href =
-      'https://accounts.google.com/o/oauth2/v2/auth?client_id=166892546465-mvg7ktdjmtmk5r288qnp1060f8ajb0a1.apps.googleusercontent.com&redirect_uri=http://localhost:3000&response_type=code&scope=email+profile';
+    window.location.href = `${process.env.REACT_APP_GOOGLE_LOGIN}`;
   };
 
   return (

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -3,7 +3,7 @@ import ScrapCard from 'components/_common/ScrapCard/ScrapCard';
 import SearchBar from 'components/_common/SearchBar/SearchBar';
 import Tag from 'components/_common/Tag/Tag';
 import UserCard from 'components/_common/UserCard/UserCard';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { S } from './style';
 import { PostListMock } from 'mock/postMock';
 import { OneScrapType } from 'types/ScrapType';
@@ -12,6 +12,7 @@ import { UserType } from 'types/UserType';
 import { tagListMock } from 'mock/tagMock';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { postLogin } from 'apis/member';
+import UserModal from '../../components/Modal/UserModal/UserModal';
 
 const MainPage = () => {
   const location = useLocation();
@@ -22,19 +23,24 @@ const MainPage = () => {
     const searchParams = new URLSearchParams(location.search); //구글 로그인 redirect URI
     const code = searchParams.get('code'); //URI의 파라미터에서 code를 추출
     if (code) {
-      console.log('code', code);
       login(code); //추출한 code로 백엔드에 로그인 api 요청
     }
   }, []);
+  const [isFirst, setIsFirst] = useState<boolean>();
 
+  let nickname;
   // 백엔드에 로그인 api 요청
   const login = async (code: string) => {
     try {
       const data = await postLogin(code);
-      console.log('data', data);
-      localStorage.setItem('papersToken', data.accessToken);
-      localStorage.setItem('nickname', data.nickname);
-      navigate('/');
+      console.log(data);
+      if (data) {
+        data.isFirst && setIsFirst(true);
+        nickname = data.nickname;
+        localStorage.setItem('papersToken', data.accessToken);
+        localStorage.setItem('nickname', data.nickname);
+        navigate('/');
+      }
     } catch (error) {
       console.log(error);
     }
@@ -42,6 +48,9 @@ const MainPage = () => {
 
   return (
     <S.Wrapper>
+      {isFirst && nickname && (
+        <UserModal userName={nickname} imgUrl={''} userDetail={''} />
+      )}
       <S.Header>
         {/* 검색바 */}
         <SearchBar />

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -3,53 +3,35 @@ import ScrapCard from 'components/_common/ScrapCard/ScrapCard';
 import SearchBar from 'components/_common/SearchBar/SearchBar';
 import Tag from 'components/_common/Tag/Tag';
 import UserCard from 'components/_common/UserCard/UserCard';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { S } from './style';
 import { PostListMock } from 'mock/postMock';
 import { OneScrapType } from 'types/ScrapType';
 import { userListMock } from 'mock/userMock';
 import { UserType } from 'types/UserType';
 import { tagListMock } from 'mock/tagMock';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { postLogin } from 'apis/member';
+import { useParams } from 'react-router-dom';
+import { useUserInfoQuery } from '../../hooks/apis/member';
+import { LocalStorage } from '../../utils/localStorage';
 import UserModal from '../../components/Modal/UserModal/UserModal';
 
 const MainPage = () => {
-  const location = useLocation();
-  const navigate = useNavigate();
+  const params = useParams();
 
-  // 구글 로그인 처리
-  useEffect(() => {
-    const searchParams = new URLSearchParams(location.search); //구글 로그인 redirect URI
-    const code = searchParams.get('code'); //URI의 파라미터에서 code를 추출
-    if (code) {
-      login(code); //추출한 code로 백엔드에 로그인 api 요청
-    }
-  }, []);
-  const [isFirst, setIsFirst] = useState<boolean>();
+  const nickname = LocalStorage.getNickname()!;
+  const userInfo = useUserInfoQuery(nickname);
 
-  let nickname;
-  // 백엔드에 로그인 api 요청
-  const login = async (code: string) => {
-    try {
-      const data = await postLogin(code);
-      console.log(data);
-      if (data) {
-        data.isFirst && setIsFirst(true);
-        nickname = data.nickname;
-        localStorage.setItem('papersToken', data.accessToken);
-        localStorage.setItem('nickname', data.nickname);
-        navigate('/');
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  //파람에 isFirst가 true이면 모달
+  const isFirst = params.isFirst;
 
   return (
     <S.Wrapper>
-      {isFirst && nickname && (
-        <UserModal userName={nickname} imgUrl={''} userDetail={''} />
+      {isFirst && userInfo && (
+        <UserModal
+          userName={userInfo.nickname!}
+          imgUrl={userInfo.profileImgUrl!}
+          userDetail={userInfo.introduce!}
+        />
       )}
       <S.Header>
         {/* 검색바 */}

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -3,33 +3,34 @@ import ScrapCard from 'components/_common/ScrapCard/ScrapCard';
 import SearchBar from 'components/_common/SearchBar/SearchBar';
 import Tag from 'components/_common/Tag/Tag';
 import UserCard from 'components/_common/UserCard/UserCard';
-import React from 'react';
 import { S } from './style';
 import { PostListMock } from 'mock/postMock';
 import { OneScrapType } from 'types/ScrapType';
-import { userListMock } from 'mock/userMock';
+import { UserMock, userListMock } from 'mock/userMock';
 import { UserType } from 'types/UserType';
 import { tagListMock } from 'mock/tagMock';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useUserInfoQuery } from '../../hooks/apis/member';
 import { LocalStorage } from '../../utils/localStorage';
-import UserModal from '../../components/Modal/UserModal/UserModal';
-
+import { useRecommendScrapQuery } from '../../hooks/apis/scrap';
+import UserModal from 'components/Modal/UserModal/UserModal';
+import { useRecommendUsersQuery } from '../../hooks/apis/member';
 const MainPage = () => {
   const params = useParams();
-
+  const isFirst = params.isFirst;
   const nickname = LocalStorage.getNickname()!;
   const userInfo = useUserInfoQuery(nickname);
+  const scrapList = useRecommendScrapQuery();
 
-  //파람에 isFirst가 true이면 모달
-  const isFirst = params.isFirst;
+  const userList = useRecommendUsersQuery();
+  console.log('userList', userList);
 
   return (
     <S.Wrapper>
       {isFirst && userInfo && (
         <UserModal
+          imgUrl={userInfo.profileImgUrl}
           userName={userInfo.nickname!}
-          imgUrl={userInfo.profileImgUrl!}
           userDetail={userInfo.introduce!}
         />
       )}
@@ -66,7 +67,7 @@ const MainPage = () => {
                     title={scrap.scrapTitle}
                     content={scrap.scrapContent}
                     heartCnt={10}
-                    author={scrap.writerInfo.nickname}
+                    author={scrap.writerNickname}
                   />
                 )
             )}
@@ -90,7 +91,7 @@ const MainPage = () => {
                     title={scrap.scrapTitle}
                     content={scrap.scrapContent}
                     heartCnt={10}
-                    author={scrap.writerInfo.nickname}
+                    author={scrap.writerNickname}
                   />
                 )
             )}
@@ -101,7 +102,7 @@ const MainPage = () => {
         <S.Section>
           <S.Text>추천 유저</S.Text>
           <S.CardList>
-            {userListMock.map(
+            {userList.map(
               (user: UserType, index: number) =>
                 index < 3 && (
                   <UserCard

--- a/src/router/Private.tsx
+++ b/src/router/Private.tsx
@@ -1,0 +1,14 @@
+import { Outlet, useNavigate } from 'react-router-dom';
+
+const PrivateRoute = () => {
+  const navigate = useNavigate();
+  const accessToken = localStorage.getItem('papersToken');
+
+  if (!accessToken) {
+    navigate('/login');
+  }
+
+  return <Outlet />;
+};
+
+export default PrivateRoute;

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -11,44 +11,50 @@ import LoginPage from 'pages/LoginPage/LoginPage';
 import ModalLayout from '../layout/ModalLayout/ModalLayout';
 import FollowingPage from '../pages/FollowingPage/FollowingPage';
 import LikePage from '../pages/LikePage/LikePage';
+import PrivateRoute from './Private';
 
 const router = createBrowserRouter([
-  { element: <LoginPage />, path: '/login' },
   {
-    element: <ModalLayout />,
+    element: <PrivateRoute />,
     children: [
+      { element: <LoginPage />, path: '/login' },
       {
-        element: <NavbarLayout />,
+        element: <ModalLayout />,
         children: [
           {
-            element: <FolderPage />,
-            path: '/folder/:nickname'
+            element: <NavbarLayout />,
+            children: [
+              {
+                element: <FolderPage />,
+                path: '/folder/:nickname'
+              },
+              {
+                element: <FollowingPage />,
+                path: '/following'
+              },
+              {
+                element: <LikePage />,
+                path: '/like'
+              }
+            ]
           },
           {
-            element: <FollowingPage />,
-            path: '/following'
+            element: <HeaderLayout />,
+            children: [
+              {
+                path: '/',
+                element: <MainPage />
+              },
+              { element: <CategoryPage />, path: '/category/:categoryId' },
+              { element: <SearchPage />, path: '/search' },
+              { element: <DetailPage />, path: '/detail/:scrapId' }
+            ]
           },
           {
-            element: <LikePage />,
-            path: '/like'
+            element: <HeaderLayout isWriteButton={false} />,
+            children: [{ element: <ScrapWritePage />, path: '/scrap-write' }]
           }
         ]
-      },
-      {
-        element: <HeaderLayout />,
-        children: [
-          {
-            path: '/',
-            element: <MainPage />
-          },
-          { element: <CategoryPage />, path: '/category/:categoryId' },
-          { element: <SearchPage />, path: '/search' },
-          { element: <DetailPage />, path: '/detail/:scrapId' }
-        ]
-      },
-      {
-        element: <HeaderLayout isWriteButton={false} />,
-        children: [{ element: <ScrapWritePage />, path: '/scrap-write' }]
       }
     ]
   }

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -12,8 +12,13 @@ import ModalLayout from '../layout/ModalLayout/ModalLayout';
 import FollowingPage from '../pages/FollowingPage/FollowingPage';
 import LikePage from '../pages/LikePage/LikePage';
 import PrivateRoute from './Private';
+import AuthPage from '../pages/AuthPage/AuthPage';
 
 const router = createBrowserRouter([
+  {
+    element: <AuthPage />,
+    path: '/auth'
+  },
   {
     element: <PrivateRoute />,
     children: [
@@ -51,7 +56,7 @@ const router = createBrowserRouter([
             ]
           },
           {
-            element: <HeaderLayout isWriteButton={false} />,
+            element: <HeaderLayout />,
             children: [{ element: <ScrapWritePage />, path: '/scrap-write' }]
           }
         ]

--- a/src/types/ScrapType.ts
+++ b/src/types/ScrapType.ts
@@ -1,16 +1,20 @@
 import { UserType } from './UserType';
 import { CategoryKeyType } from 'constants/Category';
 
-export type OneScrapType = {
-  imgUrl: string;
+export type SimpleOneScrapType = {
+  imgUrl: string; //빠짐
   scrapId: number;
   scrapTitle: string;
-  scrapContent: string;
+  scrapContent: string; //빠짐
   scrapLink: string;
-  writerInfo: UserType; //작성자 정보
-  CreatedAt: Date; //작성 날짜
-  heartCnt: number; //좋아요 개수
-  commentCnt: number; //댓글 개수
+  writerNickname: string;
+  writerProfile: string | null;
+  CreatedAt: Date; //빠짐
+  heartCnt: number; //빠짐
+  commentCnt: number; //빠짐
+};
+
+export type OneScrapType = SimpleOneScrapType & {
   tags: OneTagType[];
   category: CategoryKeyType;
 };

--- a/src/utils/localStorage.tsx
+++ b/src/utils/localStorage.tsx
@@ -1,0 +1,8 @@
+export const LocalStorage = {
+  getNickname: () => {
+    return localStorage.getItem('nickname');
+  },
+  setNickname: (newNickname: string) => {
+    localStorage.setItem('nickname', newNickname);
+  }
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요
>
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 구글 로그인시 auth 페이지로 리다이렉트 페이지를 변경하였습니다.
> 구글 로그인 주소를 env  파일로 옮겼습니다 
> 유저정보 불러오는 api 를 연결하였습니다.
> 추천 유저 불러오는 api를 연결했습니다.
> 프라이빗 라우트를 추가해서 accessToken이 없으면, 재요청이 실패하면 로그인 페이지로 이동되게 하였습니다. 
> 로컬 스토리지에 넣는 로직을 LocalStorage라는 파일에 따로 분리하엿습니다. 닉네임도 이를 통해 관리해야 할 것 같습니다. 

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
