### PR TITLE
스크랩 생성 api 연결

### DIFF
--- a/src/apis/scraps.ts
+++ b/src/apis/scraps.ts
@@ -3,20 +3,26 @@ import { axiosInstance, axiosInstanceWithoutToken } from './axiosInstance';
 import { CategoryKeyType, SearchRangeKeyType } from '../constants/Category';
 
 export type OneNewScrapType = {
+  writerNickname: string;
   scrapTitle: string;
   scrapLink: string;
   scrapContent: string;
-  tags: OneTag[];
+  category: string;
   folderId: number;
+  tags: OneTag[];
 };
 
 type OneTag = {
-  content: string;
+  tagName: string;
 };
 
 //스크랩 생성
-export const postNewScrap = async (newScrapInfo: OneNewScrapType) => {
-  const { data } = await axiosInstance.post('/scraps', { ...newScrapInfo });
+export const postNewScrap = async (newScrapInfo: FormData) => {
+  const { data } = await axiosInstance.post(
+    '/scraps',
+    { ...newScrapInfo },
+    { headers: { 'Content-Type': 'multipart/form-data' } }
+  );
   return data;
 };
 

--- a/src/atom/modal.tsx
+++ b/src/atom/modal.tsx
@@ -5,7 +5,8 @@ export const folderModalAtom = atom({
   default: {
     option: 'edit',
     open: false,
-    scrapId: 1
+    scrapId: 1,
+    folderId: -1
   }
 });
 

--- a/src/components/Modal/FolderModal/FolderEdit/FolderEdit.tsx
+++ b/src/components/Modal/FolderModal/FolderEdit/FolderEdit.tsx
@@ -14,7 +14,8 @@ const FolderEdit = ({ folderList }: { folderList: OneFolderType[] }) => {
     setFolderModalState({
       option: 'add',
       open: true,
-      scrapId: 0
+      scrapId: 0,
+      folderId: -1
     });
   };
   return (

--- a/src/components/Modal/FolderModal/FolderModal.tsx
+++ b/src/components/Modal/FolderModal/FolderModal.tsx
@@ -31,6 +31,15 @@ const FolderModal = ({ folderList }: { folderList: OneFolderType[] }) => {
         <FolderSelect folderList={folderList} />
       </>
     </BasicModal>
+  ) : folderModalState.option === 'scrapWrite' ? (
+    <BasicModal width={450} height={500} onCloseModal={onModalClose}>
+      <>
+        <S.EditIconWrapper>
+          <S.Title>폴더 선택</S.Title>
+        </S.EditIconWrapper>
+        <FolderSelect folderList={folderList} />
+      </>
+    </BasicModal>
   ) : (
     <BasicModal width={450} height={200} onCloseModal={onModalClose}>
       <S.FlexBox>

--- a/src/components/Modal/FolderModal/FolderSelect/FolderSelect.tsx
+++ b/src/components/Modal/FolderModal/FolderSelect/FolderSelect.tsx
@@ -4,21 +4,30 @@ import { useState } from 'react';
 import { OneFolderType } from '../../../../types/FolderType';
 import BasicButton from '../../../_common/BasicButton/BasicButton';
 import { usePatchScrapMutation } from '../../../../hooks/apis/scrap';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { folderModalAtom } from '../../../../atom/modal';
 
 const FolderSelect = ({ folderList }: { folderList: OneFolderType[] }) => {
   const [selectId, setSelectId] = useState<number | null>(null);
   const { patchNewScrapMutate } = usePatchScrapMutation();
-  const folderModalState = useRecoilValue(folderModalAtom);
+  const [folderModalState, setFolderModalState] =
+    useRecoilState(folderModalAtom);
 
   const onClickChangeFolder = () => {
     if (selectId) {
       console.log(selectId);
-      patchNewScrapMutate({
-        folderId: selectId,
-        scrapId: folderModalState.scrapId
-      });
+      if (folderModalState.option === 'select') {
+        patchNewScrapMutate({
+          folderId: selectId,
+          scrapId: folderModalState.scrapId
+        });
+      } else if (folderModalState.option === 'scrapWrite') {
+        setFolderModalState((prev) => ({
+          ...prev,
+          open: false,
+          folderId: selectId
+        }));
+      }
     }
   };
 

--- a/src/components/_common/BasicContentCard/BasicContentCard.tsx
+++ b/src/components/_common/BasicContentCard/BasicContentCard.tsx
@@ -47,7 +47,8 @@ const BasicContentCard = (props: BasicCardProps) => {
                   setFolderModal({
                     option: 'select',
                     scrapId: scrapId,
-                    open: true
+                    open: true,
+                    folderId: -1
                   });
                 }
               },

--- a/src/components/_common/LineNavbar/LineNavbar.tsx
+++ b/src/components/_common/LineNavbar/LineNavbar.tsx
@@ -60,7 +60,8 @@ const LineNavbar = ({ isMine, title, folderList }: NavbarProps) => {
               setIsEditModalOpen({
                 option: 'edit',
                 open: true,
-                scrapId: 0
+                scrapId: 0,
+                folderId: -1
               });
             }}
           >
@@ -107,7 +108,8 @@ const LineNavbar = ({ isMine, title, folderList }: NavbarProps) => {
               setIsEditModalOpen({
                 option: 'add',
                 open: true,
-                scrapId: 0
+                scrapId: 0,
+                folderId: -1
               });
             }}
           >

--- a/src/components/_common/Tag/Tag.tsx
+++ b/src/components/_common/Tag/Tag.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { S } from './style';
 import { ReactComponent as DeleteIcon } from 'asset/_common/delete.svg';
-import { OneTagType } from 'types/ScrapType';
-import { NewTagType } from 'types/TagType';
 
 export type TagProps = {
-  tagId: number | string;
+  tagId?: number | string;
   tagName: string;
   onDelete?: (id: string) => void; //TagCreator에서 X 클릭 시 이벤트 핸들러
 };

--- a/src/components/_common/TagCreator/TagCreator.tsx
+++ b/src/components/_common/TagCreator/TagCreator.tsx
@@ -7,16 +7,16 @@ import { NewTagType } from 'types/TagType';
 
 type TagCreatorProps = {
   isCreator?: boolean;
-  tags?: OneTagType[];
+  newTagList: NewTagType[];
+  setNewTagList?: React.Dispatch<React.SetStateAction<NewTagType[]>>;
 };
 
-const TagCreator = ({ isCreator = true, tags = [] }: TagCreatorProps) => {
+const TagCreator = ({
+  isCreator = true,
+  newTagList = [],
+  setNewTagList
+}: TagCreatorProps) => {
   const [input, setInput] = useState('');
-  const [tagList, setTagList] = useState<NewTagType[]>([
-    ...tags.map((tag) => {
-      return { tagId: v4(), tagName: tag.tagName };
-    })
-  ]);
 
   //태그 추가 (엔터 입력 시)
   const onEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -30,13 +30,16 @@ const TagCreator = ({ isCreator = true, tags = [] }: TagCreatorProps) => {
       tagId: v4(),
       tagName: input
     };
-    setTagList((currTagList) => [...currTagList, newTag]);
+    setNewTagList && setNewTagList((currTagList) => [...currTagList, newTag]);
     setInput('');
   };
 
   //태그 삭제 (X 버튼 클릭 시)
   const onDelete = (id: string) => {
-    setTagList((currTagList) => currTagList.filter((tag) => tag.tagId !== id));
+    setNewTagList &&
+      setNewTagList((currTagList) =>
+        currTagList.filter((tag) => tag.tagId !== id)
+      );
   };
 
   const inputWidthRef = useRef<HTMLSpanElement>(null);
@@ -52,7 +55,7 @@ const TagCreator = ({ isCreator = true, tags = [] }: TagCreatorProps) => {
   return (
     <S.Wrapper>
       {/* 태그 리스트 */}
-      {tagList.map((tag: NewTagType, index: number) =>
+      {newTagList.map((tag: NewTagType, index: number) =>
         isCreator ? (
           <Tag
             key={index}

--- a/src/constants/Category.tsx
+++ b/src/constants/Category.tsx
@@ -1,17 +1,19 @@
 export const CategoryWithoutAll = {
-  NEWS: '시사',
-  CULTURE: '문화',
-  TRAVEL: '여행',
-  IT: 'IT',
-  LIFE: '라이프',
-  KNOWLEDGE: '지식',
-  ETC: '기타'
+  news: '시사',
+  culture: '문화',
+  travel: '여행',
+  it: 'IT',
+  life: '라이프',
+  knowledge: '지식',
+  etc: '기타'
 } as const;
 
 export const CATEGORY: { [key: string]: string } = {
   ALL: '카테고리',
   ...CategoryWithoutAll
 } as const;
+
+export type CategoryWithoutAllKeyType = keyof typeof CategoryWithoutAll;
 
 export type CategoryType = typeof CATEGORY;
 

--- a/src/hooks/apis/scrap.ts
+++ b/src/hooks/apis/scrap.ts
@@ -20,9 +20,9 @@ export const useNewScrapMutation = () => {
   const { mutate: postNewScrapMutate } = useMutation<
     AxiosResponseType,
     AxiosError,
-    OneNewScrapType
+    FormData
   >({
-    mutationFn: (scrapInfo: OneNewScrapType) => postNewScrap(scrapInfo)
+    mutationFn: (scrapInfo: FormData) => postNewScrap(scrapInfo)
     // onSuccess: queryClient.invalidateQueries('scrap')
   });
   return { postNewScrapMutate };

--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -24,7 +24,12 @@ const DetailPage = () => {
         <RightArrow />
       </S.FlexWrapper>
       <S.Title>{scrapTitle}</S.Title>
-      <TagCreator isCreator={false} tags={tags} />
+      <TagCreator
+        isCreator={false}
+        newTagList={tags.map((tag) => {
+          return { tagName: tag.tagName };
+        })}
+      />
       <S.UserInfoWrapper>
         <CircleBox imgUrl={writerProfile} size={'small'} />
         <S.FlexColumnWrapper>

--- a/src/types/TagType.ts
+++ b/src/types/TagType.ts
@@ -1,4 +1,4 @@
 export type NewTagType = {
-  tagId: string;
+  tagId?: string;
   tagName: string;
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요
>
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### folderId 추가
- 스크랩 생성 api 요청시 folderId를 요청 바디에 넘겨야하기 때문에, modal.tsx의 folderModalAtom에 folderId를 추가하였습니다. 
- 스크랩 작성 페이지에서 폴더선택 버튼을 누를경우, folderModalAtom의 options로 'scrapWrite'를 주었고, 이경우  FolderSelect.tsx에서의 컨트롤이 달라집니다. 
- 예를 들어, 마이페이지의 내폴더에서 이동할 폴더를 선택할 경우에는 options로 'select'를 주어, 해당 스크랩을 다른 폴더로 이동시키는 로직이 실행됩니다. 하지만 스크랩 작성 페이지에서 폴더를 선택할 때는, 선택된 폴더의 folderId를 알아내어 folderModalAtom에 저장하는 로직이 실행됩니다.

### 스크랩 생성 api 연결
- 스크랩 생성 api를 연결하였습니다. 이때 요청 바디로 formData를 사용하였습니다. 아직 백엔드에 에러가 있어서 테스트는 하지 못한 상태입니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
